### PR TITLE
feat: expose signTypedData

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,18 +1,19 @@
-export { signTx } from "./utils/signTx";
+export { sendTx, signTx } from './utils/signTx';
+export { signTypedData } from './utils/signTypedData';
 
-export { Mangata } from "./mangata";
+export { Mangata } from './mangata';
 
-export * from "./utils/bigConstants";
-export * from "./utils/bnConstants";
-export * from "./utils/bnUtility";
-export * from "./utils/toFixed";
-export * from "./utils/isMultiSwapAssetTransactionSuccessful";
-export * from "./utils/isBuyAssetTransactionSuccessful"
-export * from "./utils/isSellAssetTransactionSuccessful"
-export { setLoggerOptions } from "./utils/mangataLogger";
+export * from './utils/bigConstants';
+export * from './utils/bnConstants';
+export * from './utils/bnUtility';
+export * from './utils/toFixed';
+export * from './utils/isMultiSwapAssetTransactionSuccessful';
+export * from './utils/isBuyAssetTransactionSuccessful';
+export * from './utils/isSellAssetTransactionSuccessful';
+export { setLoggerOptions } from './utils/mangataLogger';
 
-export * from "./types/common";
-export * from "./types/query";
-export * from "./types/tokens";
-export * from "./types/xyk";
-export * from "./types/utility";
+export * from './types/common';
+export * from './types/query';
+export * from './types/tokens';
+export * from './types/xyk';
+export * from './types/utility';

--- a/packages/sdk/src/utils/signTx.ts
+++ b/packages/sdk/src/utils/signTx.ts
@@ -17,7 +17,7 @@ import { truncatedString } from './truncatedString';
 import { getTxError } from './getTxError';
 import { logger } from './mangataLogger';
 import { hexToU8a } from '@polkadot/util';
-import { signTypedData_v4 } from './signTypedData';
+import { signTypedData } from './signTypedData';
 
 const subscribeToExtrinsic = async (
   api: ApiPromise,
@@ -145,6 +145,55 @@ const subscribeToExtrinsic = async (
   }
 };
 
+export const sendTx = async (
+  api: ApiPromise,
+  tx: SubmittableExtrinsic<'promise'>,
+  userAddress: string,
+  txOptions?: Partial<TxOptions>
+): Promise<MangataGenericEvent[]> => {
+  /* eslint-disable no-async-promise-executor */
+  return new Promise<MangataGenericEvent[]>(async (resolve, reject) => {
+    const nonce = await getTxNonce(api, userAddress, txOptions);
+
+    logger.debug(
+      `submitting Tx[${tx.hash.toString()}]who: ${userAddress} nonce: ${nonce.toString()} `
+    );
+
+    try {
+      const subscriptionState = { isSubscribed: false };
+
+      const unsub = await api.rpc.author.submitAndWatchExtrinsic(
+        tx,
+        async (status) => {
+          await subscribeToExtrinsic(
+            api,
+            tx,
+            { status },
+            userAddress,
+            txOptions,
+            subscriptionState,
+            resolve,
+            reject,
+            unsub
+          );
+        }
+      );
+    } catch (error: any) {
+      const nonce = await api.rpc.system.accountNextIndex(userAddress);
+      const currentNonce: BN = nonce.toBn();
+      dbInstance.setNonce(userAddress, currentNonce);
+
+      reject({
+        data:
+          error.message ||
+          error.description ||
+          error.data?.toString() ||
+          error.toString(),
+      });
+    }
+  });
+};
+
 export const signTx = async (
   api: ApiPromise,
   tx: SubmittableExtrinsic<'promise'>,
@@ -166,12 +215,7 @@ export const signTx = async (
       const subscriptionState = { isSubscribed: false };
 
       if (txOptions?.wagmiConfig) {
-        const transaction = api.createType(
-          'Extrinsic',
-          { method: tx.method },
-          { version: tx.version }
-        );
-        const signRes = await signTypedData_v4(
+        const signRes = await signTypedData(
           api,
           tx,
           txOptions?.wagmiConfig,
@@ -179,26 +223,25 @@ export const signTx = async (
         );
 
         if (!signRes) {
-          reject('SignTypedData error');
+          reject('Signature error');
           return;
         }
 
         const { payload, signature, address } = signRes;
 
-        const created_signature = api.createType('EthereumSignature', hexToU8a(signature));
-        
-        transaction.addSignature(
-          address,
-          created_signature,
-          payload.toHex()
+        const created_signature = api.createType(
+          'EthereumSignature',
+          hexToU8a(signature)
         );
 
+        tx.addSignature(address, created_signature, payload.toHex());
+
         const unsub = await api.rpc.author.submitAndWatchExtrinsic(
-          transaction,
+          tx,
           async (status) => {
             await subscribeToExtrinsic(
               api,
-              transaction,
+              tx,
               { status },
               extractedAccount,
               txOptions,

--- a/packages/sdk/src/utils/signTypedData.ts
+++ b/packages/sdk/src/utils/signTypedData.ts
@@ -8,7 +8,7 @@ import type { SignatureOptions, IExtrinsicEra } from '@polkadot/types/types';
 import { GenericExtrinsicPayloadV4 } from '@polkadot/types';
 import { Call } from '@polkadot/types/interfaces';
 import type { HexString } from '@polkadot/util/types';
-import { signTypedData, type Config } from '@wagmi/core';
+import { signTypedData as _signTypedData, type Config } from '@wagmi/core';
 
 interface SigningResult {
   header: Header | null;
@@ -22,12 +22,19 @@ export interface SignTypedData_v4 {
   signature: HexString | null;
 }
 
-function makeEraOptions(api: ApiPromise, registry: Registry, partialOptions: Partial<SignatureOptions>, signingInfo: SigningResult) {
+function makeEraOptions(
+  api: ApiPromise,
+  registry: Registry,
+  partialOptions: Partial<SignatureOptions>,
+  signingInfo: SigningResult
+) {
   const { header, mortalLength, nonce } = signingInfo;
 
   if (!header) {
     if (partialOptions.era && !partialOptions.blockHash) {
-      throw new Error('Expected blockHash to be passed alongside non-immortal era options');
+      throw new Error(
+        'Expected blockHash to be passed alongside non-immortal era options'
+      );
     }
     if (isNumber(partialOptions.era)) {
       // since we have no header, it is immortal, remove any option overrides
@@ -49,8 +56,11 @@ function makeEraOptions(api: ApiPromise, registry: Registry, partialOptions: Par
   });
 }
 
-function makeSignOptions(api: ApiPromise, partialOptions: Partial<SignatureOptions>, extras: Partial<SignatureOptions>): SignatureOptions {
-
+function makeSignOptions(
+  api: ApiPromise,
+  partialOptions: Partial<SignatureOptions>,
+  extras: Partial<SignatureOptions>
+): SignatureOptions {
   return objectSpread(
     { blockHash: api.genesisHash, genesisHash: api.genesisHash },
     partialOptions,
@@ -59,32 +69,46 @@ function makeSignOptions(api: ApiPromise, partialOptions: Partial<SignatureOptio
       runtimeVersion: api.runtimeVersion,
       signedExtensions: api.registry.signedExtensions,
       version: undefined,
-    },
+    }
   );
 }
 
-export async function signTypedData_v4(api: ApiPromise, tx: SubmittableExtrinsic<"promise">, config: Config, address?: string): Promise<SignTypedData_v4> {
+export async function signTypedData(
+  api: ApiPromise,
+  tx: SubmittableExtrinsic<'promise'>,
+  config: Config,
+  address?: string
+): Promise<SignTypedData_v4> {
   const options: Partial<SignatureOptions> = {};
 
   if (!address) {
     throw new Error('No address found');
   }
 
-  const signingInfo = await api.derive.tx.signingInfo(address, options.nonce, options.era);
+  const signingInfo = await api.derive.tx.signingInfo(
+    address,
+    options.nonce,
+    options.era
+  );
   const eraOptions = makeEraOptions(api, api.registry, options, signingInfo);
-  const payload = tx.inner.signature.createPayload(tx.method as Call, eraOptions);
+  const payload = tx.inner.signature.createPayload(
+    tx.method as Call,
+    eraOptions
+  );
   const raw_payload = payload.toU8a({ method: true });
 
-  const result = await api.rpc.metamask.get_eip712_sign_data(tx.toHex().slice(2));
+  const result = await api.rpc.metamask.get_eip712_sign_data(
+    tx.toHex().slice(2)
+  );
   const data = JSON.parse(result.toString());
   data.message.tx = u8aToHex(raw_payload).slice(2);
   data.account = address;
-  
-  const signature = await signTypedData(config, data);
+
+  const signature = await _signTypedData(config, data);
 
   return {
     address,
     payload,
-    signature: signature || null
-  }
+    signature: signature || null,
+  };
 }


### PR DESCRIPTION
- exposes `signTypedData` and `sendTx`
- `signTx` continues to sign and send transactions for backward compatibility
- prerequisite for https://mangatafinance.atlassian.net/browse/GASP-2068``